### PR TITLE
fix render table with a header only

### DIFF
--- a/spec/cmark/renderers/html_renderer_spec.cr
+++ b/spec/cmark/renderers/html_renderer_spec.cr
@@ -377,6 +377,20 @@ describe "HTMLRenderer" do
     end
   end
 
+  describe "table with a header only" do
+    markdown = <<-MD
+      | foo | bar | fii | bor |
+      | --- |:--- |:---:| ---:|
+      MD
+    root = Cmark.parse_document(markdown, extensions: Extension::Table)
+    node = root.first_child.not_nil!
+
+    it "renders" do
+      renderer = HTMLRenderer.new
+      renderer.render(node).should eq node.render_html
+    end
+  end
+
   describe "footnote elements" do
     markdown = <<-MD
       This[^one] is a reference; this[^two] one another; this[^one] the same as the first one.

--- a/src/cmark/renderers/html_renderer.cr
+++ b/src/cmark/renderers/html_renderer.cr
@@ -268,10 +268,11 @@ require "uri"
           cr
           out "</tbody>"
           cr
-          out "</table>"
-          cr
         end
+
         @table_needs_closing_table_body = false
+        cr
+        out "</table>"
         cr
       end
     end


### PR DESCRIPTION
Render next markdown

```
| Foo | Bar |
| :---: | :---: |
```

returns

```
<table> <thead> <tr> <th align="center">Foo</th> <th align="center">Bar</th> </tr> </thead>
```

after this fix will return proper HTML:

```
<table> <thead> <tr> <th align="center">Foo</th> <th align="center">Bar</th> </tr> </thead> </table>
```

Also tested on tables with many rows.

See for reference: https://github.com/github/cmark-gfm/blob/master/extensions/table.c#L664-L672