### PR TITLE
Update shard version so it builds with Crystal 1.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ description: Crystal C bindings for cmark-gfm to work with Commonmark and Github
 authors:
   - Amaury Trujillo
 
-crystal: 0.31.1
+crystal: ">= 0.31.1"
 
 scripts:
   postinstall: cd ext && make


### PR DESCRIPTION
Fixes #6 

Built locally against Crystal 1.0, and all specs pass:

```
cr-cmark-gfm on  crystal1.0 [!] via 🔮 v1.0.0
❯ crystal spec
..................................................................................................................................................................................................................

Finished in 9.97 milliseconds
210 examples, 0 failures, 0 errors, 0 pending
```