### PR TITLE
fix running on Arch Linux

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -5,10 +5,6 @@ all: libcmark-gfm.a
 
 libcmark-gfm.a: $(CMARK) $(SOURCES)
 	cd $(CMARK) && INSTALL_PREFIX=.. make cmake_build
-	cp $(CMARK)/src/*.h .
-	cp $(CMARK)/extensions/*.h .
-	cp $(CMARK)/build/src/*.h .
-	cp $(CMARK)/build/extensions/*.h .
 	cp $(CMARK)/build/src/*.a .
 	cp $(CMARK)/build/extensions/*.a .
 
@@ -19,4 +15,4 @@ clean:
 	rm -rf cmark-*
 
 distclean: clean
-	rm -rf *.a *.h
+	rm -rf *.a

--- a/src/cmark/lib_cmark.cr
+++ b/src/cmark/lib_cmark.cr
@@ -1,5 +1,5 @@
 module Cmark
-  @[Link(ldflags: "#{__DIR__}/../../ext/*.a")]
+  @[Link(ldflags: "#{__DIR__}/../../ext/libcmark-gfm-extensions.a #{__DIR__}/../../ext/libcmark-gfm.a")]
   lib LibCmark
     # Options affecting rendering
 


### PR DESCRIPTION
without this I received an error on Arch Linux:

```sh
crystal spec
/usr/bin/ld: /mnt/disk/ruby/crystal/cr-cmark-gfm/src/cmark/../../ext/libcmark-gfm-extensions.a(table.c.o): in function `matches':
table.c:(.text+0xb81): undefined reference to `cmark_arena_push'
/usr/bin/ld: table.c:(.text+0xbda): undefined reference to `cmark_arena_pop'
/usr/bin/ld: /mnt/disk/ruby/crystal/cr-cmark-gfm/src/cmark/../../ext/libcmark-gfm-extensions.a(table.c.o): in function `try_opening_table_block':
table.c:(.text+0xe7f): undefined reference to `cmark_arena_push'
/usr/bin/ld: table.c:(.text+0xef5): undefined reference to `cmark_arena_pop'
/usr/bin/ld: table.c:(.text+0xf09): undefined reference to `cmark_arena_pop'
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `cc "${@}" -o /home/mama/snap/crystal/common/.cache/crystal/crystal-run-spec.tmp  -rdynamic -L/var/lib/snapd/snap/crystal/1005/bin/../lib/crystal /mnt/disk/ruby/crystal/cr-cmark-gfm/src/cmark/../../ext/*.a -lpcre -lm -lgc -lpthread -levent  -lrt -ldl
```

Probably it fixes https://github.com/amauryt/cr-cmark-gfm/issues/8