### PR TITLE
fix build

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -10,7 +10,14 @@ endif
 all: build
 
 build: $(CMARK) $(SOURCES)
-	cd $(CMARK) && INSTALL_PREFIX=.. make cmake_build
+	mkdir -p $(CMARK)/build
+	cd $(CMARK)/build && cmake .. \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=.. \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	cd $(CMARK)/build && make
+
 	cp $(CMARK)/build/src/libcmark-gfm.a .
 	cp $(CMARK)/build/src/libcmark-gfm.$(COMPILED_EXT)* .
 	cp $(CMARK)/build/extensions/libcmark-gfm-extensions.a .


### PR DESCRIPTION
Fixes:

```
cd cmark-gfm && INSTALL_PREFIX=.. make cmake_build
make[1]: Entering directory '/home/runner/work/shards-info/shards-info/lib/cmark/ext/cmark-gfm'
mkdir -p build; \
cd build; \
cmake .. \
	-G "Unix Makefiles" \
	-DCMAKE_BUILD_TYPE= \
	-DCMAKE_INSTALL_PREFIX=.. \
	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
make[1]: *** [Makefile:40: build] Error 1
make[1]: Leaving directory '/home/runner/work/shards-info/shards-info/lib/cmark/ext/cmark-gfm'
make: *** [Makefile:7: libcmark-gfm.a] Error 2
Error: Process completed with exit code 1.
```

https://github.com/mamantoha/shards-info/actions/runs/14193162406/job/39762257840?pr=299